### PR TITLE
cleanup cruft, use sqlite3 again

### DIFF
--- a/client.go
+++ b/client.go
@@ -122,14 +122,6 @@ func (c *EntClientConfig) NewEntDB(dataSource string) (*entsql.Driver, error) {
 		return nil, fmt.Errorf("failed connecting to database: %w", err)
 	}
 
-	if entDialect == dialect.SQLite {
-		// enable foreign keys in sqlite
-		if _, err := db.Exec("PRAGMA foreign_keys = on;", nil); err != nil {
-			db.Close()
-			return nil, fmt.Errorf("failed to enable enable foreign keys: %w", err)
-		}
-	}
-
 	// verify db connection using ping
 	if err := db.Ping(); err != nil {
 		return nil, fmt.Errorf("failed verifying database connection: %w", err)
@@ -153,7 +145,7 @@ func Healthcheck(client *entsql.Driver) func(ctx context.Context) error {
 // corresponding to the given dialect
 func CheckEntDialect(d string) (string, error) {
 	switch d {
-	case "sqlite":
+	case "sqlite3":
 		return dialect.SQLite, nil
 	case "libsql":
 		return dialect.SQLite, nil
@@ -167,7 +159,7 @@ func CheckEntDialect(d string) (string, error) {
 // CheckMultiwriteSupport checks if the dialect supports multiwrite
 func CheckMultiwriteSupport(d string) bool {
 	switch d {
-	case "sqlite":
+	case "sqlite3":
 		return true
 	case "libsql":
 		return true

--- a/client_test.go
+++ b/client_test.go
@@ -17,12 +17,12 @@ func TestCheckDialect(t *testing.T) {
 	}{
 		{
 			name:     "sqlite",
-			dialect:  "sqlite",
+			dialect:  "sqlite3",
 			expected: "sqlite3",
 		},
 		{
 			name:     "libsql",
-			dialect:  "sqlite",
+			dialect:  "libsql",
 			expected: "sqlite3",
 		},
 		{
@@ -62,12 +62,12 @@ func TestMultiWriteSupport(t *testing.T) {
 	}{
 		{
 			name:     "sqlite",
-			dialect:  "sqlite",
+			dialect:  "sqlite3",
 			expected: true,
 		},
 		{
 			name:     "libsql",
-			dialect:  "sqlite",
+			dialect:  "libsql",
 			expected: true,
 		},
 		{


### PR DESCRIPTION
- removes set of FK, this is now handled by the wrapper 
- switch back to `sqlite3` as the dialect 
- fixes libsql tests 