### PR TITLE
feat: add mapping id to id mixin

### DIFF
--- a/mixin/idmixin.go
+++ b/mixin/idmixin.go
@@ -35,6 +35,7 @@ func (i IDMixin) Fields() []ent.Field {
 					entoas.Skip(true),
 					entgql.Skip(),
 				).
+				Unique().
 				DefaultFunc(func() string { return ulids.New().String() }),
 		)
 	}

--- a/mixin/idmixin.go
+++ b/mixin/idmixin.go
@@ -1,6 +1,7 @@
 package mixin
 
 import (
+	"entgo.io/contrib/entgql"
 	"entgo.io/contrib/entoas"
 	"entgo.io/ent"
 	"entgo.io/ent/schema/field"
@@ -12,14 +13,31 @@ import (
 // IDMixin holds the schema definition for the ID
 type IDMixin struct {
 	mixin.Schema
+	// ExcludeMappingID to exclude the mapping ID field to the schema that can be used without exposing the primary ID
+	// by default, it is included in any schema that uses this mixin.
+	ExcludeMappingID bool
 }
 
 // Fields of the IDMixin.
-func (IDMixin) Fields() []ent.Field {
-	return []ent.Field{
+func (i IDMixin) Fields() []ent.Field {
+	fields := []ent.Field{
 		field.String("id").
 			Immutable().
 			Annotations(entoas.Annotation{ReadOnly: true}).
 			DefaultFunc(func() string { return ulids.New().String() }),
 	}
+
+	if !i.ExcludeMappingID {
+		fields = append(fields,
+			field.String("mapping_id").
+				Immutable().
+				Annotations(
+					entoas.Skip(true),
+					entgql.Skip(),
+				).
+				DefaultFunc(func() string { return ulids.New().String() }),
+		)
+	}
+
+	return fields
 }


### PR DESCRIPTION
This adds a `mapping_id` column that is not returned to the user that can be used in things such as claims without exposing the actual primary key of the table. By default, if the `idmixin` is included, this field is added to the schema. It can be excluded by: 

```go
emixin.IDMixin{
	ExcludeMappingID: true,
},
```

This is a breaking change to any existing database because it attempts to add a not null column without default:

```
 Cannot add a NOT NULL column with default value NULL (1)
```

Relates to https://github.com/datumforge/datum/issues/866