### PR TITLE
fix: singular version for get by id query, add missing delete mutation

### DIFF
--- a/.yamlfmt
+++ b/.yamlfmt
@@ -1,0 +1,2 @@
+formatter:
+  retain_line_breaks: true

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,5 +1,10 @@
 version: '3'
 
+includes:
+  example:
+    taskfile: ./vanilla/_example/Taskfile.yml
+    dir: ./vanilla/_example
+
 tasks:
   go:lint:
     desc: runs golangci-lint, the most annoying opinionated linter ever

--- a/genhooks/templates/query.tpl
+++ b/genhooks/templates/query.tpl
@@ -44,7 +44,7 @@ query GetAll{{ .Name | ToPlural }} {
 
 {{- if not .IsHistory }}
 query Get{{ .Name }}ByID(${{ .Name | ToLowerCamel }}Id: ID!) {
-  {{ .Name | ToLowerCamel | ToPlural }}(id: ${{ .Name | ToLowerCamel }}Id) {
+  {{ .Name | ToLowerCamel }}(id: ${{ .Name | ToLowerCamel }}Id) {
     {{- range .Fields }}
     {{.}}
     {{- end}}

--- a/genhooks/templates/query.tpl
+++ b/genhooks/templates/query.tpl
@@ -28,6 +28,12 @@ mutation Create{{ .Name }}($input: Create{{ .Name }}Input!) {
     }
   }
 }
+
+mutation Delete{{ .Name }}($delete{{ .Name }}Id: ID!) {
+  delete{{ .Name }}(id: $delete{{ .Name }}Id) {
+    deletedID
+  }
+}
 {{- end}}
 
 query GetAll{{ .Name | ToPlural }} {

--- a/vanilla/_example/query/organization.graphql
+++ b/vanilla/_example/query/organization.graphql
@@ -41,6 +41,12 @@ mutation CreateOrganization($input: CreateOrganizationInput!) {
   }
 }
 
+mutation DeleteOrganization($deleteOrganizationId: ID!) {
+  deleteOrganization(id: $deleteOrganizationId) {
+    deletedID
+  }
+}
+
 query GetAllOrganizations {
   organizations {
     edges {

--- a/vanilla/_example/query/organization.graphql
+++ b/vanilla/_example/query/organization.graphql
@@ -57,7 +57,7 @@ query GetAllOrganizations {
   }
 }
 query GetOrganizationByID($organizationId: ID!) {
-  organizations(id: $organizationId) {
+  organization(id: $organizationId) {
     createdAt
     createdBy
     description

--- a/vanilla/_example/query/orgmembership.graphql
+++ b/vanilla/_example/query/orgmembership.graphql
@@ -45,7 +45,7 @@ query GetAllOrgMemberships {
   }
 }
 query GetOrgMembershipByID($orgMembershipId: ID!) {
-  orgMemberships(id: $orgMembershipId) {
+  orgMembership(id: $orgMembershipId) {
     id
     organizationID
     role

--- a/vanilla/_example/query/orgmembership.graphql
+++ b/vanilla/_example/query/orgmembership.graphql
@@ -32,6 +32,12 @@ mutation CreateOrgMembership($input: CreateOrgMembershipInput!) {
   }
 }
 
+mutation DeleteOrgMembership($deleteOrgMembershipId: ID!) {
+  deleteOrgMembership(id: $deleteOrgMembershipId) {
+    deletedID
+  }
+}
+
 query GetAllOrgMemberships {
   orgMemberships {
     edges {


### PR DESCRIPTION
- fixes a bug where the generated query for `GetByID` was using the plural instead of singular
- adds the missing `Delete` Mutation expected by the client generation in datum